### PR TITLE
Issues 16 18 19

### DIFF
--- a/magik-company-buffer-cache.el
+++ b/magik-company-buffer-cache.el
@@ -86,12 +86,14 @@
 			   (match-string 1))))))
     (when params
       (setq params (mapcar #'string-trim (split-string params "," t)))
-      (setq params (cl-remove-if (lambda (param)
-				   (or (string-suffix-p "_optional" param)
-				       (string-suffix-p "_gather" param)))
-				 params)))
-
-    params))
+      (setq params
+            (cl-loop for param in params
+                     if (or (string-prefix-p "_optional" param)
+                            (string-prefix-p "_gather" param))
+                     collect (nth 1 (split-string param " "))
+                     else
+                     collect param)))
+      params))
 
 (defun magik-company--exemplar-slots ()
   "Retrieve the slots from a exemplar or mixin."

--- a/magik-company-prefixes.el
+++ b/magik-company-prefixes.el
@@ -106,8 +106,13 @@
 (defun magik-company--at-global-prefix ()
   "Detect if the point is at a possible global."
   (save-excursion
-    (if (re-search-backward "^\\s-*\\(\\sw+\\)\\=" (line-beginning-position) t)
-	t
+    (if (re-search-backward "\\b\\(\\sw+\\)\\_>" (line-beginning-position) t)
+	(let ((start (match-beginning 0)))
+	  (if (and start
+		   (> start (point-min))
+		   (not (eq (char-before start) ?.)))
+	      t
+	    nil))
       nil)))
 
 (defun magik-company--at-object-prefix ()
@@ -115,12 +120,14 @@
 Allows for single words or two words connected with a ':'."
   (save-excursion
     (if (or
-	 (re-search-backward "\\b\\(\\sw+\\):\\(\\sw+\\)\\=" (line-beginning-position) t)
-	 (re-search-backward "\\b\\(\\sw+\\)\\=" (line-beginning-position) t))
-	(not (or (eq (following-char) ?.)
-		 (save-excursion
-		   (goto-char (match-beginning 0))
-		   (re-search-backward "\\." (line-beginning-position) t))))
+	 (re-search-backward "\\b\\(\\sw+\\):\\(\\sw+\\)\\_>" (line-beginning-position) t)
+	 (re-search-backward "\\b\\(\\sw+\\)\\_>" (line-beginning-position) t))
+	(let ((start (match-beginning 0)))
+	  (if (and start
+		   (> start (point-min))
+		   (not (eq (char-before start) ?.)))
+	      t
+	    nil))
       nil)))
 
 (provide 'magik-company-prefixes)


### PR DESCRIPTION
Change the first parameter after _gather or _optional to not be deleted from the local buffer cache 
closes #18 

Change the prefixes allowed for variables to be more flexible 
closes #16 

Change the prefixes allowed for globals to be more flexible 
closes #19 