### PR TITLE
Resolve local buffer cache not added into candidates

### DIFF
--- a/magik-company.el
+++ b/magik-company.el
@@ -117,7 +117,7 @@ COMMAND, ARG, IGNORED"
 
   (let ((magik-candidates '()))
     (when (string= magik-company--major-mode magik-company--buffer-mode)
-      (magik-company--buffer-local-candidates magik-candidates))
+      (setq magik-candidates (magik-company--buffer-local-candidates magik-candidates)))
 
     (when (or magik-company-prefix-at-globals
 	      magik-company-prefix-at-dynamics)
@@ -160,7 +160,8 @@ COMMAND, ARG, IGNORED"
     (setq magik-candidates (append magik-candidates magik-company--variables-candidates))
 
     (setq magik-company--exemplar-candidate (magik-company--filter-candidates magik-company--classname-cache magik-candidates))
-    (setq magik-candidates (append magik-candidates magik-company--exemplar-candidate))))
+    (setq magik-candidates (append magik-candidates magik-company--exemplar-candidate)))
+  magik-candidates)
 
 (defun magik-company--filter-candidates (new-candidates existing-candidates)
   "Filter NEW-CANDIDATES.


### PR DESCRIPTION
Resolve local buffer cache not added into candidates.
By writing into the magik candidates list after passing as param